### PR TITLE
Adding mktorrent dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 ```
 sudo pip3 install requests ptpimg_uploader
 ```
-* mediainfo和ffmpeg，例子：对于ubuntu
+* mediainfo、ffmpeg和mktorrent，例子：对于ubuntu
 ```
-sudo apt-get install mediainfo ffmpeg
+sudo apt-get install mediainfo ffmpeg mktorrent
 ```
 
 ## 运行


### PR DESCRIPTION
WSL2上默认没有安装mktorrent包，需要额外安装。